### PR TITLE
Split dependencies in development and runtime

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,9 @@
   "author": "brian@briancavalier.com",
   "license": "MIT",
   "dependencies": {
-    "@most/core": "^1.3.4",
+    "@most/core": "^1.3.4"
+  },
+  "devDependencies": {
     "@most/types": "^1.0.1",
     "microbundle": "^0.11.0",
     "typescript": "^3.4.1"


### PR DESCRIPTION
This commit splits the dependencies between those required during
development and those required during runtime.

Signed-off-by: Frederik Krautwald <fkrautwald@gmail.com>